### PR TITLE
Implement LangChainManager integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ pip install chopperfix
 ```
 Ensure that all dependencies such as **LangChain**, **Selenium**, **Playwright**, **SQLAlchemy**, and **spaCy** are properly configured in your environment.
 
+#### ✨ **Using LangChainManager**
+
+`LangChainManager` provides helper methods powered by OpenAI models to suggest selectors and generate descriptions.
+
+```python
+from llm_integration.langchain_manager import LangChainManager
+
+manager = LangChainManager()
+selector = manager.suggest_alternative_selector(
+    "<button id='ok'>OK</button>",
+    "//button[@id='submit']",
+    "click",
+)
+print(selector)
+```
+
 #### 🛠️ **Integration with Playwright**
 
 1. **Setting up Playwright**

--- a/chopperfix/chopper_decorators.py
+++ b/chopperfix/chopper_decorators.py
@@ -1,11 +1,11 @@
 from functools import wraps  # Importa el decorador 'wraps' para mantener la metadata de la función original
 from learning.pattern_storage import PatternStorage  # Importa la clase 'PatternStorage' para almacenar patrones
-from llm_integration.adalflow_manager import AdalFlowManager, fix_xpath
+from llm_integration.langchain_manager import LangChainManager, fix_xpath
 from bs4 import BeautifulSoup  # Necesario para extraer el contexto del HTML
 
-# Inicializa las instancias de AdalFlowManager y PatternStorage
+# Inicializa las instancias de LangChainManager y PatternStorage
 pattern_storage = PatternStorage()
-adalFlow_Manger = AdalFlowManager()
+adalFlow_Manger = LangChainManager()
 
 from lxml import etree
 

--- a/learning/pattern_storage.py
+++ b/learning/pattern_storage.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from datetime import datetime
 
-from llm_integration.adalflow_manager import AdalFlowManager, fix_xpath
+from llm_integration.langchain_manager import LangChainManager, fix_xpath
 
 Base = declarative_base()
 
@@ -196,7 +196,7 @@ class PatternStorage:
         return None
 
     def get_replacement_selector(self, failed_selector, url,action_name):
-        adalFlow_Manger = AdalFlowManager()
+        adalFlow_Manger = LangChainManager()
         normalized_failed_selector = self.normalize_selector(failed_selector)
         normalized_url = self.normalize_url(url)
 

--- a/llm_integration/__init__.py
+++ b/llm_integration/__init__.py
@@ -1,0 +1,1 @@
+from .langchain_manager import LangChainManager, fix_xpath, clean_xpath

--- a/llm_integration/langchain_manager.py
+++ b/llm_integration/langchain_manager.py
@@ -1,0 +1,194 @@
+import re
+from bs4 import BeautifulSoup
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts import PromptTemplate
+
+
+def fix_xpath(xpath: str) -> str:
+    pattern = r"(@[\w-]+)=['\"]?([^'\"]+)['\"]?"
+    corrected_xpath = re.sub(pattern, r'\1="\2"', xpath)
+    if corrected_xpath.count('"') % 2 != 0:
+        corrected_xpath = corrected_xpath.replace('="', '="').replace(']"', ']')
+    return corrected_xpath
+
+
+def clean_xpath(raw_response: str) -> str:
+    cleaned_xpath = raw_response.strip().replace("```xpath", "").replace("```", "").strip()
+    return cleaned_xpath
+
+
+class LangChainManager:
+    def __init__(self, model_name: str = "gpt-3.5-turbo-0125", temperature: float = 0.0):
+        self.llm = ChatOpenAI(model=model_name, temperature=temperature)
+
+    def suggest_alternative_selector(
+        self,
+        html_content: str,
+        failed_selector: str,
+        action_name: str,
+        full_element_html: str | None = None,
+        parent_element: str | None = None,
+        child_elements: list[str] | None = None,
+        sibling_elements: list[str] | None = None,
+    ) -> str | None:
+        template = (
+            "Generate a robust and valid XPath selector based on the following context and HTML."
+            " Ensure all attribute values are enclosed in single quotes (`'`).\n\n"
+            "- Action to perform: {action_name}\n"
+            "- Failed selector: {failed_selector}\n"
+            "- Full element HTML: {full_element_html}\n"
+            "- Parent element HTML: {parent_element}\n"
+            "- Child elements HTML: {child_elements}\n"
+            "- Sibling elements HTML: {sibling_elements}\n"
+            "- Current HTML:\n```html\n{html_content}\n```\n\n"
+            "Return only the XPath selector."
+        )
+        prompt = PromptTemplate(
+            input_variables=[
+                "action_name",
+                "failed_selector",
+                "full_element_html",
+                "parent_element",
+                "child_elements",
+                "sibling_elements",
+                "html_content",
+            ],
+            template=template,
+        )
+        formatted = prompt.format(
+            action_name=action_name,
+            failed_selector=failed_selector,
+            full_element_html=full_element_html or "Not available",
+            parent_element=parent_element or "Not available",
+            child_elements=", ".join(child_elements) if child_elements else "Not available",
+            sibling_elements=", ".join(sibling_elements) if sibling_elements else "Not available",
+            html_content=html_content,
+        )
+        try:
+            response = self.llm.predict(formatted)
+            selector = fix_xpath(clean_xpath(response))
+            return selector if selector else None
+        except Exception as e:
+            print(f"[ERROR] LangChain suggestion failed: {e}")
+            return None
+
+    def generate_description(
+        self,
+        action_name: str,
+        selector: str,
+        url: str,
+        html_content: str,
+        full_element_html: str | None = None,
+        parent_element: str | None = None,
+        child_elements: list[str] | None = None,
+        sibling_elements: list[str] | None = None,
+    ) -> str | None:
+        soup = BeautifulSoup(html_content, "html.parser")
+        important = soup.find_all([
+            "input",
+            "button",
+            "a",
+            "select",
+            "textarea",
+            "form",
+            "div",
+            "span",
+            "section",
+            "article",
+            "header",
+            "footer",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "p",
+            "li",
+            "ul",
+            "ol",
+            "table",
+            "tr",
+            "td",
+            "th",
+            "thead",
+            "tbody",
+            "tfoot",
+            "img",
+            "svg",
+            "video",
+            "audio",
+            "canvas",
+        ])
+        truncated_html = "\n".join(str(el) for el in important[:50])
+        template = (
+            "Given the following details of a web automation action:\n"
+            "- Action: {action_name}\n"
+            "- Selector: {selector}\n"
+            "- URL: {url}\n"
+            "- Full element HTML: {full_element_html}\n"
+            "- Parent element HTML: {parent_element}\n"
+            "- Child elements HTML: {child_elements}\n"
+            "- Sibling elements HTML: {sibling_elements}\n"
+            "- HTML Content (truncated):\n```\n{truncated_html}\n```\n\n"
+            "Please generate a concise description of this action in the context of the web page's structure."
+        )
+        prompt = PromptTemplate(
+            input_variables=[
+                "action_name",
+                "selector",
+                "url",
+                "full_element_html",
+                "parent_element",
+                "child_elements",
+                "sibling_elements",
+                "truncated_html",
+            ],
+            template=template,
+        )
+        formatted = prompt.format(
+            action_name=action_name,
+            selector=selector,
+            url=url,
+            full_element_html=full_element_html or "Not available",
+            parent_element=parent_element or "Not available",
+            child_elements=", ".join(child_elements) if child_elements else "Not available",
+            sibling_elements=", ".join(sibling_elements) if sibling_elements else "Not available",
+            truncated_html=truncated_html,
+        )
+        try:
+            description = self.llm.predict(formatted)
+            return description.strip()
+        except Exception as e:
+            print(f"[ERROR] LangChain description failed: {e}")
+            return None
+
+    def analyze_context_from_text(
+        self,
+        db_text_data: str,
+        failed_selector: str,
+        action_name: str,
+    ) -> str | None:
+        template = (
+            "The following is a dataset containing CSS selectors, their context, and metrics from a database:\n"
+            "```\n{db_text_data}\n```\n\n"
+            "Given this dataset, analyze the context to suggest the most suitable replacement selector "
+            "for the failed selector '{failed_selector}' in the context of the action '{action_name}'.\n\n"
+            "Return only the suggested CSS selector."
+        )
+        prompt = PromptTemplate(
+            input_variables=["db_text_data", "failed_selector", "action_name"],
+            template=template,
+        )
+        formatted = prompt.format(
+            db_text_data=db_text_data,
+            failed_selector=failed_selector,
+            action_name=action_name,
+        )
+        try:
+            selector = self.llm.predict(formatted)
+            selector = re.sub(r'[`\'"\n]', '', selector).strip()
+            return None if selector.lower() == "none" else selector
+        except Exception as e:
+            print(f"[ERROR] LangChain context analysis failed: {e}")
+            return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # LangChain y OpenAI
-adalflow
 openai
-langchain_community
+langchain
+langchain-openai
 # Selenium para automatización web
 selenium
 beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ setup(
     install_requires=[
         'sqlalchemy',
         'beautifulsoup4',
-        'adalflow',
         'openai',
+        'langchain',
+        'langchain-openai',
         'Pillow',
         'requests',
         'pydantic',

--- a/tests/test_langchain_manager.py
+++ b/tests/test_langchain_manager.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch
+
+from llm_integration.langchain_manager import LangChainManager
+
+
+class LangChainManagerTest(unittest.TestCase):
+    @patch("llm_integration.langchain_manager.ChatOpenAI")
+    def test_suggest_alternative_selector(self, mock_chat):
+        mock_chat.return_value.predict.return_value = "//input[@id='searchInput']"
+        manager = LangChainManager()
+        result = manager.suggest_alternative_selector("<input id='q'>", "//input[@id='x']", "type")
+        self.assertEqual(result, "//input[@id=\"searchInput\"]")
+        self.assertTrue(result)
+
+    @patch("llm_integration.langchain_manager.ChatOpenAI")
+    def test_generate_description(self, mock_chat):
+        mock_chat.return_value.predict.return_value = "Fill search field"
+        manager = LangChainManager()
+        desc = manager.generate_description("type", "//input", "http://t", "<html></html>")
+        self.assertEqual(desc, "Fill search field")
+        self.assertTrue(desc)
+
+    @patch("llm_integration.langchain_manager.ChatOpenAI")
+    def test_analyze_context_from_text(self, mock_chat):
+        mock_chat.return_value.predict.return_value = "//div[@id='best']"
+        manager = LangChainManager()
+        result = manager.analyze_context_from_text("data", "//div[@id='old']", "click")
+        self.assertEqual(result, "//div[@id=best]")
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wiki_ply_examples.py
+++ b/wiki_ply_examples.py
@@ -1,5 +1,6 @@
 from playwright.sync_api import sync_playwright
 from chopperfix.chopper_decorators import chopperdoc
+from llm_integration.langchain_manager import LangChainManager
 
 
 class CustomPlaywright:
@@ -72,3 +73,12 @@ patterns = storage.get_all_patterns(limit=10)
 for pattern in patterns:
     print(f"Acción: {pattern.action}, Selector: {pattern.selector}, URL: {pattern.url}, "
           f"Timestamp: {pattern.timestamp}, Descripción: {pattern.description}, Peso: {pattern.peso}")
+
+# Uso directo de LangChainManager para sugerir un selector alternativo
+manager = LangChainManager()
+suggested = manager.suggest_alternative_selector(
+    "<input id='searchInput' />",
+    "//input[@id='sear']",
+    "type",
+)
+print(suggested)


### PR DESCRIPTION
## Summary
- add a new LangChainManager powered by LangChain
- swap AdalFlowManager references for LangChainManager
- update example script and README with new manager usage
- update requirements and setup dependencies
- add unit tests covering LangChainManager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f92e2036c833189730be7efe5a065