### PR TITLE
Add self-healing and storage tests

### DIFF
--- a/tests/test_chopper_decorators.py
+++ b/tests/test_chopper_decorators.py
@@ -1,0 +1,57 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Ensure LangChain does not require a real API key during import
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from chopperfix.chopper_decorators import chopperdoc
+
+class FakePage:
+    def __init__(self):
+        self.url = 'http://example.com'
+        self._html = "<html><div id='a'></div></html>"
+    def content(self):
+        return self._html
+
+class FakeDriver:
+    def __init__(self):
+        self.page = FakePage()
+
+calls = []
+
+@chopperdoc
+def action(driver, action, **kwargs):
+    calls.append(kwargs.get('xpath'))
+    if kwargs.get('xpath') == '//bad':
+        raise Exception('fail')
+    return 'ok'
+
+class ChopperDecoratorTest(unittest.TestCase):
+    def setUp(self):
+        calls.clear()
+        self.driver = FakeDriver()
+
+    @patch('chopperfix.chopper_decorators.pattern_storage')
+    @patch('chopperfix.chopper_decorators.adalFlow_Manger')
+    def test_self_healing_flow(self, mock_manager, mock_storage):
+        mock_storage.get_replacement_selector.return_value = '//fixed'
+        mock_storage.save_pattern = MagicMock()
+        mock_manager.generate_description.return_value = 'desc'
+        mock_manager.suggest_alternative_selector.return_value = None
+
+        result = action(self.driver, 'click', xpath='//bad')
+
+        self.assertEqual(result, 'ok')
+        self.assertEqual(calls, ['//bad', '//fixed'])
+        mock_storage.get_replacement_selector.assert_called_once_with('//bad', 'http://example.com', 'click')
+        self.assertEqual(mock_storage.save_pattern.call_count, 2)
+        first_call = mock_storage.save_pattern.call_args_list[0]
+        self.assertFalse(first_call.kwargs['success'])
+        self.assertEqual(first_call.kwargs['replacement_selector'], '//fixed')
+        second_call = mock_storage.save_pattern.call_args_list[1]
+        self.assertTrue(second_call.kwargs['success'])
+        self.assertEqual(second_call.args[1], '//fixed')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pattern_storage.py
+++ b/tests/test_pattern_storage.py
@@ -1,0 +1,50 @@
+import unittest
+from learning.pattern_storage import PatternStorage, Pattern
+
+class PatternStorageTest(unittest.TestCase):
+    def setUp(self):
+        self.storage = PatternStorage('sqlite:///:memory:')
+
+    def tearDown(self):
+        self.storage.close()
+
+    def test_save_pattern_insert_and_update(self):
+        # Insert new pattern
+        self.storage.save_pattern(
+            'click',
+            "//div[@id='a']",
+            'http://example.com',
+            'desc',
+            success=True,
+            full_element_html='<div id="a"></div>',
+            parent_element='<body></body>',
+            child_elements=['<span></span>'],
+            sibling_elements=['<p></p>']
+        )
+
+        session = self.storage.session
+        patterns = session.query(Pattern).all()
+        self.assertEqual(len(patterns), 1)
+        p = patterns[0]
+        self.assertEqual(p.usage_count, 1)
+        self.assertEqual(p.success_rate, 1.0)
+        self.assertFalse(p.failed)
+        self.assertEqual(p.full_element_html, '<div id="a"></div>')
+
+        # Update existing pattern with failure
+        self.storage.save_pattern(
+            'click',
+            "//div[@id='a']",
+            'http://example.com',
+            'fail desc',
+            success=False,
+            replacement_selector="//div[@id='b']"
+        )
+        updated = session.query(Pattern).first()
+        self.assertEqual(updated.usage_count, 2)
+        self.assertAlmostEqual(updated.success_rate, 0.5)
+        self.assertTrue(updated.failed)
+        self.assertEqual(updated.replacement_selector, "//div[@id='b']")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add PatternStorage test covering insert/update logic
- add chopper_decorators self-healing test using mocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436c9c150c8331816a6ce0dd872358