### PR TITLE
Fix Playwright example to use chopperdoc

### DIFF
--- a/examples/playwright_example.py
+++ b/examples/playwright_example.py
@@ -1,21 +1,35 @@
 from playwright.sync_api import sync_playwright
 
-from chopperfix.chopper_decorators import action_logger
+from chopperfix.chopper_decorators import chopperdoc
 
 
 class CustomPlaywright:
-    def __init__(self):
+    def __init__(self, timeout=10000, retry_attempts=1):
         self.playwright = sync_playwright().start()
-        self.browser = self.playwright.chromium.launch(headless=False)  # Abre el navegador en modo visible
+        self.browser = self.playwright.chromium.launch(headless=False)
         self.page = self.browser.new_page()
+        self.page.set_default_timeout(timeout)
+        self.retry_attempts = retry_attempts
 
-    @action_logger
+    @chopperdoc
+    def perform_action(self, action, **kwargs):
+        for attempt in range(self.retry_attempts):
+            try:
+                if action == 'click':
+                    self.page.click(kwargs['selector'])
+                elif action == 'navigate':
+                    self.page.goto(kwargs.get('url', ''))
+                return True
+            except Exception as e:
+                print(f"Intento {attempt + 1} fallido: {e}")
+                if attempt == self.retry_attempts - 1:
+                    raise
+
     def click(self, selector):
-        self.page.click(selector)
+        return self.perform_action('click', selector=selector)
 
-    @action_logger
     def navigate(self, url):
-        self.page.goto(url)
+        return self.perform_action('navigate', url=url)
 
     def close(self):
         self.browser.close()


### PR DESCRIPTION
## Summary
- swap action_logger for chopperdoc in the Playwright example
- update the example to show the correct chopperdoc function signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684459c7d6688331904ad00fe8ecd9c8